### PR TITLE
[RFC]fdt.c: fdt chosen cmd had off-by-one issue

### DIFF
--- a/cmd/fdt.c
+++ b/cmd/fdt.c
@@ -705,7 +705,7 @@ static int do_fdt(struct cmd_tbl *cmdtp, int flag, int argc, char *const argv[])
 
 		if (argc == 4) {
 			initrd_start = hextoul(argv[2], NULL);
-			initrd_end = initrd_start + hextoul(argv[3], NULL) - 1;
+			initrd_end = initrd_start + hextoul(argv[3], NULL);
 		}
 
 		fdt_chosen(working_fdt);


### PR DESCRIPTION
The searching will shift-by-1 and never match the bootconfig thus always not found bootconfig this case.

===
Kernel:
	data = (char *)initrd_end - BOOTCONFIG_MAGIC_LEN;
	for (i = 0; i < 4; i++) {
                if (!memcmp(data, BOOTCONFIG_MAGIC, BOOTCONFIG_MAGIC_LEN))
                        goto found;
                data--;
	}
---
u-boot:
	initrd_end = initrd_start + hextoul(argv[3], NULL) - 1;

That would be off-by-one apprently and matching fail for bootconfig. Both u-boot and kernel worth a fix.

An out-of-tree patch for kernel to relax the searching is available but not ready for submit.
https://github.com/99degree/linux/commit/9d9ea454fe857a9f550d7e60957253e176e8e123